### PR TITLE
chore: migrate API client to new /v1 route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,15 @@ The template includes a complete auth setup designed to work with the companion 
 
 - **AuthProvider** (`src/lib/auth.tsx`) — React context tracking `isAuthenticated`, `isLoading`, `email`, and `userId`
 - **Automatic token refresh** (`src/api/api.ts`) — 401 responses trigger a refresh attempt; concurrent requests are coalesced into a single refresh call
-- **Session check on load** — `GET /auth/me` validates the session on mount
+- **Session check on load** — `GET /v1/auth/me` validates the session on mount
 - **Auth in router context** — `auth` is available in route `beforeLoad` for route guards
 
 ### How it works
 
-1. Backend sets httpOnly cookies (`app_access` + `app_refresh`) on login
+1. Backend sets httpOnly cookies (`app_access` + `app_refresh`) on login; the
+   refresh cookie is path-scoped to `/v1/auth/refresh`
 2. All API requests include cookies via `credentials: "include"`
-3. On 401, the client POSTs to `/auth/refresh` to rotate tokens
+3. On 401, the client POSTs to `/v1/auth/refresh` to rotate tokens
 4. If refresh succeeds, the original request is retried transparently
 5. If refresh fails, `onUnauthorized` fires and auth state is cleared
 
@@ -254,7 +255,7 @@ await renderWithFileRoutes(<div />, {
 })
 ```
 
-MSW handlers are configured in `src/api/handlers.ts`. A default handler for `/auth/me` (returns 401) is included to suppress warnings during tests.
+MSW handlers are configured in `src/api/handlers.ts`. A default handler for `/v1/auth/me` (returns 401) is included to suppress warnings during tests.
 
 ## Project Structure
 
@@ -316,7 +317,7 @@ Set `VITE_LOG_LEVEL` to control the minimum level (default: `debug` in dev, `war
 
 ### Feature Flags
 
-`FeatureFlagProvider` fetches flags from the API's `GET /flags` endpoint (cached via TanStack Query, refetches on window focus). If the API call fails, it falls back to `VITE_FEATURE_*` env vars.
+`FeatureFlagProvider` fetches flags from the API's `GET /v1/flags` endpoint (cached via TanStack Query, refetches on window focus). If the API call fails, it falls back to `VITE_FEATURE_*` env vars.
 
 Use the `useFeatureFlag("flag_name")` hook or the `<Feature flag="flag_name">` component for conditional rendering.
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -14,7 +14,7 @@ let refreshPromise: Promise<boolean> | null = null
 
 async function attemptRefresh(): Promise<boolean> {
   try {
-    const res = await fetch(`${baseUrl}/auth/refresh`, {
+    const res = await fetch(`${baseUrl}/v1/auth/refresh`, {
       method: "POST",
       credentials: "include",
     })
@@ -37,7 +37,10 @@ export const api = ky.create({
 
         // Don't try to refresh if this IS the refresh request (prevent loop)
         const url = request.url
-        if (url.includes("/auth/refresh") || url.includes("/auth/jwt/logout")) {
+        if (
+          url.includes("/v1/auth/refresh") ||
+          url.includes("/v1/auth/jwt/logout")
+        ) {
           if (onUnauthorized) onUnauthorized()
           return
         }

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -9,6 +9,6 @@ import { http, HttpResponse, type HttpHandler } from "msw"
  */
 
 export const handlers: HttpHandler[] = [
-  // Return 401 for /auth/me by default (unauthenticated)
-  http.get("*/auth/me", () => HttpResponse.json(null, { status: 401 })),
+  // Return 401 for /v1/auth/me by default (unauthenticated)
+  http.get("*/v1/auth/me", () => HttpResponse.json(null, { status: 401 })),
 ]

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -45,7 +45,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = useCallback(async () => {
     try {
-      await api.post("auth/jwt/logout")
+      await api.post("v1/auth/jwt/logout")
     } catch {
       // Clear state regardless of fetch success
     }
@@ -61,7 +61,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const checkAuth = useCallback(async () => {
     try {
       const user = await api
-        .get("auth/me")
+        .get("v1/auth/me")
         .json<{ id: string; email: string; name: string | null }>()
       setIsAuthenticated(true)
       setEmail(user.email)

--- a/src/lib/feature-flags.tsx
+++ b/src/lib/feature-flags.tsx
@@ -39,7 +39,7 @@ export function FeatureFlagProvider({
     queryKey: ["feature-flags"],
     queryFn: async () => {
       try {
-        return await api.get("flags").json<FlagMap>()
+        return await api.get("v1/flags").json<FlagMap>()
       } catch {
         return getEnvFlags()
       }


### PR DESCRIPTION
Closes #24

[api-template](https://github.com/ag-tech-group/api-template) moved every application route under a `/v1` prefix in ag-tech-group/api-template#21. Infrastructure routes (`/`, `/health`, `/docs`, `/openapi.json`) stay unversioned. The refresh cookie is now path-scoped to `/v1/auth/refresh`. This catches the web client up before it's pointed at an API built from the updated template.

## Path map applied

| Before | After |
| --- | --- |
| `/auth/register`, `/auth/jwt/login`, `/auth/jwt/logout`, `/auth/refresh`, `/auth/me` | `/v1/auth/...` |
| `/admin/users/{id}/role` | `/v1/admin/users/{id}/role` |
| `/notes`, `/notes/{id}` | `/v1/notes`, `/v1/notes/{id}` |
| `/flags` | `/v1/flags` |
| `/`, `/health`, `/docs`, `/openapi.json` | unchanged |

## What changed

5 files, +16/-12 — all hand-written API path strings:

- **`src/api/api.ts`** — silent-refresh `fetch()` targets `/v1/auth/refresh`; the `afterResponse` "don't refresh on the refresh request" guard now matches `/v1/auth/refresh` and `/v1/auth/jwt/logout`.
- **`src/lib/auth.tsx`** — `checkAuth()` calls `/v1/auth/me`; `logout()` calls `/v1/auth/jwt/logout`.
- **`src/lib/feature-flags.tsx`** — `FeatureFlagProvider` fetches `/v1/flags`.
- **`src/api/handlers.ts`** — MSW default unauthenticated handler now matches `*/v1/auth/me`.
- **`README.md`** — `/auth/me`, `/auth/refresh`, `/flags` references updated; documented that the refresh cookie is path-scoped to `/v1/auth/refresh`.

Codegen path note (from issue checklist): `baseUrl` stays the bare origin (`VITE_API_URL`, e.g. `http://localhost:8000`). The `/v1` lives in the request paths — both in hand-written ky calls (`api.get("v1/auth/me")`) and in the orval-generated hooks (which produce strings like `` `/v1/auth/me` ``). Running `pnpm generate-api` against a `/v1`-prefixed spec drops them straight into the generated client; nothing in `baseUrl` to fight over, no `/v1/v1/...` duplication.

Dev proxy note: `vite.config.ts` has no `server.proxy` — this template uses CORS via `VITE_API_URL`, not a `/api`-style proxy. Nothing to rewrite there.

The generated orval client (`src/api/generated/`) is not committed — the template has never committed it, and the `verify-api-types` CI job is gated on `vars.OPENAPI_URL`. Consumers regenerate against their own backend.

## Verification

Backend smoke test against a fresh `api-template` checkout of `main` (`uv sync`, `alembic upgrade head`, `uv run uvicorn app.main:app`):

- Old unprefixed paths return **404**: `GET /auth/me`, `POST /auth/jwt/login`, `POST /auth/refresh`, `GET /flags`, `GET /notes`.
- Infrastructure paths return **200**: `/`, `/health`, `/docs`, `/openapi.json`.
- `POST /v1/auth/register` → 201 → `POST /v1/auth/jwt/login` → 204 with `app_access` (`Path=/`) and `app_refresh` (`Path=/v1/auth/refresh`).
- `GET /v1/auth/me` with cookies → 200; `GET /v1/notes` → 200.
- `POST /v1/auth/refresh` → 204 (cookies rotated, refresh cookie still `Path=/v1/auth/refresh`); subsequent `GET /v1/auth/me` with rotated cookies → 200.
- `POST /v1/auth/jwt/logout` → 204; subsequent `GET /v1/auth/me` → 401.
- Cookie-path scoping verified: `GET /v1/auth/me` carries only `app_access`; `POST /v1/auth/refresh` carries both. Confirms the frontend must request the exact path `/v1/auth/refresh` for the refresh cookie to be sent — which is what `attemptRefresh()` now does.

Codegen check: `OPENAPI_URL=http://localhost:<port>/openapi.json pnpm generate-api` produces hooks like `useGetV1AuthMe` calling `` `/v1/auth/me` ``, no `/v1/v1/...` duplication.

Local CI checks all green: `pnpm lint` (0 errors; the 4 fast-refresh warnings in `src/routes/__root.tsx` are pre-existing and the file isn't touched by this PR), `pnpm format:check`, `pnpm tsc --noEmit`, `pnpm test:run` (2/2). Husky pre-commit ran the production `vite build` cleanly.

Recommend a manual browser pass locally before merge: with `VITE_API_URL=http://localhost:8000` and a `/v1`-prefixed api-template running, open `http://localhost:5173` and confirm the initial `GET /v1/auth/me` (401) and `GET /v1/flags` requests fire in the network panel, with no `/auth/me` or `/flags` requests appearing.
