### PR TITLE
refactor: move error and not-found components to router defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ src/
 │   ├── ui/                 # shadcn/ui components (Button, Card, Input, Label)
 │   ├── theme-provider.tsx  # Dark/light/system theme context
 │   ├── theme-toggle.tsx    # Theme cycle button
-│   ├── error-boundary.tsx  # Root error component with retry
+│   ├── error-boundary.tsx  # Default error boundary with retry
 │   └── not-found.tsx       # 404 page
 ├── lib/
 │   ├── analytics.tsx       # AnalyticsProvider + useAnalytics hook

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -3,7 +3,7 @@ import type { ErrorComponentProps } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 import { logger } from "@/lib/logger"
 
-export function RootErrorComponent({ error, reset }: ErrorComponentProps) {
+export function ErrorBoundary({ error, reset }: ErrorComponentProps) {
   logger.error("Uncaught error in route component", {
     message: error.message,
     stack: error.stack,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,8 @@ import { RouterProvider, createRouter } from "@tanstack/react-router"
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { toast } from "sonner"
+import { ErrorBoundary } from "./components/error-boundary"
+import { NotFound } from "./components/not-found"
 import { ThemeProvider } from "./components/theme-provider"
 import { Skeleton } from "./components/ui/skeleton"
 import "./index.css"
@@ -41,6 +43,8 @@ const router = createRouter({
   },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  defaultNotFoundComponent: NotFound,
+  defaultErrorComponent: ErrorBoundary,
 })
 
 declare module "@tanstack/react-router" {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,8 +6,6 @@ import {
   useRouter,
 } from "@tanstack/react-router"
 import { Toaster } from "sonner"
-import { RootErrorComponent } from "@/components/error-boundary"
-import { NotFound } from "@/components/not-found"
 import { useAnalytics } from "@/lib/analytics"
 
 const TanStackRouterDevtools = import.meta.env.PROD
@@ -41,8 +39,6 @@ interface RouterContext {
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
-  notFoundComponent: NotFound,
-  errorComponent: RootErrorComponent,
 })
 
 function RouteTracker() {


### PR DESCRIPTION
## Summary
- Register the error boundary and not-found component on the router via `defaultErrorComponent` / `defaultNotFoundComponent` in `main.tsx` instead of `errorComponent` / `notFoundComponent` on `__root.tsx`. This lets the boundary catch errors thrown by the root route itself — the route-level prop can't, since the boundary is hosted inside the same route it's protecting.
- Rename `RootErrorComponent` → `ErrorBoundary` so the export matches the `error-boundary.tsx` filename (easier IDE jump-to-symbol and grep).
- Per-route `errorComponent` / `notFoundComponent` props still work for routes that want to override (e.g., a dashboard with inline error UI that preserves the nav).

## Test plan
- [ ] `pnpm dev` — app boots normally, no console errors
- [ ] Visit a bogus path (e.g. `/does-not-exist`) — 404 page renders
- [ ] Throw inside a route component — error page renders with working "Try again" / "Go home" buttons
- [ ] `pnpm build` and `pnpm test:run` both pass