### PR TITLE
chore: bump CI actions onto the Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -49,15 +49,15 @@ jobs:
     if: ${{ vars.OPENAPI_URL != '' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"


### PR DESCRIPTION
## What

Bump the three GitHub Actions used in CI to their current major versions:

- `actions/checkout` v4 → v6
- `pnpm/action-setup` v4 → v6
- `actions/setup-node` v4 → v6

## Why

The previously pinned majors run on the **Node 20 action runtime**, which has reached end-of-life. GitHub progressively deprecates EOL action runtimes (as it did with Node 16, which began annotating every run with warnings). All three current majors run on the **Node 24** runtime.

The **project** Node version is unchanged — `node-version: "24"` already matches the `package.json` `engines` field (`>=24.0.0`). This PR only updates the runtime the JavaScript-based actions themselves execute on.