### PR TITLE
chore: release v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-template",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
First tagged release. Promotes the current state of the template to a v1.0.0 baseline.

The recent /v1 API client migration, security/scaffolding backport, production-learnings sweep, router error/not-found refactor, and CI runtime modernization together form a coherent stable scaffold worth pinning.

**Going forward:** manual version bumps on meaningful PRs; release notes via GitHub Releases (no CHANGELOG file).