### PR TITLE
chore: revert manifest version bump — keep at scaffold starter (0.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-template",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.1.0",
   "type": "module",
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
The `version` field in a template manifest is the **scaffold starter version** new projects inherit when generated from the template, not the template's own release version. Bumping it to 1.0.0 in #28 was incorrect: any project scaffolded after that PR would start at 1.0.0 instead of 0.1.0, defeating the purpose of a clean baseline.

Reverts `package.json` back to `0.1.0`.

The template's release history is still tracked via **git tags and GitHub Releases** (see the `v1.0.0` release). After this merges, the `v1.0.0` tag will be force-updated to the post-revert HEAD so checking out `v1.0.0` also gives a `0.1.0` manifest — the manifest stays decoupled from release versioning, consistently, at every ref.