### PR TITLE
chore: add SPDX license headers and NOTICE file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
+      - name: License headers
+        run: pnpm run license:check
+
       - name: Type check
         run: pnpm tsc --noEmit
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+AG Tech Web Template
+Copyright 2026 AG Technology Group LLC
+
+This product includes software developed by AG Technology Group LLC.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import js from "@eslint/js"
 import globals from "globals"
 import reactHooks from "eslint-plugin-react-hooks"

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "orval"
 
 const input = process.env.OPENAPI_URL || "http://localhost:8000/openapi.json"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "license:check": "node scripts/license-header.mjs --check --all",
+    "license:fix": "node scripts/license-header.mjs --fix --all",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/license-header.mjs
+++ b/scripts/license-header.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * license-header.mjs — stamp or verify SPDX license headers on source files.
+ *
+ * Usage:
+ *   node scripts/license-header.mjs --check --all      verify every tracked source file (CI)
+ *   node scripts/license-header.mjs --fix --all        stamp every tracked source file
+ *   node scripts/license-header.mjs --fix <files...>   stamp specific files (lint-staged)
+ *
+ * Default mode is --check. Re-running is safe: a file already carrying an
+ * SPDX identifier in its first lines is left untouched (idempotent), so the
+ * lint-staged auto-fix and the CI check can never disagree.
+ */
+
+import { execFileSync } from "node:child_process"
+import { readFileSync, writeFileSync } from "node:fs"
+
+const HEADER = [
+  "// SPDX-FileCopyrightText: 2026 AG Technology Group LLC",
+  "// SPDX-License-Identifier: Apache-2.0",
+]
+
+const SOURCE_EXT = /\.(ts|tsx|js|jsx)$/
+// Vendored deps, build output, and the Orval-generated client are never stamped.
+const SKIP_PATH = [
+  /(^|\/)node_modules\//,
+  /(^|\/)dist\//,
+  /(^|\/)build\//,
+  /(^|\/)\.next\//,
+  /(^|\/)coverage\//,
+  /(^|\/)src\/api\/generated\//,
+]
+const GENERATED_NAME = /\.gen\.(ts|tsx|js|jsx)$/
+const GENERATED_BANNER = /@generated|do not edit|automatically generated/i
+
+// Returns "skip" (with reason), "stamped" (already has a header), or "needs".
+function classify(file, content) {
+  if (!SOURCE_EXT.test(file))
+    return { status: "skip", reason: "not a source file" }
+  if (SKIP_PATH.some((re) => re.test(file)))
+    return { status: "skip", reason: "vendored/output path" }
+  if (GENERATED_NAME.test(file))
+    return { status: "skip", reason: "generated (*.gen.*)" }
+  const lines = content.split("\n")
+  if (GENERATED_BANNER.test(lines.slice(0, 15).join("\n")))
+    return { status: "skip", reason: "generated banner" }
+  if (lines.slice(0, 10).join("\n").includes("SPDX-License-Identifier"))
+    return { status: "stamped" }
+  return { status: "needs" }
+}
+
+// Insert the header at the very top — above triple-slash directives (a plain
+// comment before `/// <reference>` keeps the directive valid) — but below a
+// shebang if present. Leaves exactly one blank line before the original code.
+function applyHeader(content) {
+  const lines = content.split("\n")
+  const shebang = lines[0]?.startsWith("#!") ? lines.shift() : null
+  while (lines.length && lines[0].trim() === "") lines.shift()
+  const out = []
+  if (shebang) out.push(shebang)
+  out.push(...HEADER, "", ...lines)
+  const result = out.join("\n")
+  return result.endsWith("\n") ? result : result + "\n"
+}
+
+const args = process.argv.slice(2)
+const fix = args.includes("--fix")
+const explicit = args.filter((a) => !a.startsWith("--"))
+const targets = args.includes("--all")
+  ? execFileSync("git", ["ls-files", "*.ts", "*.tsx", "*.js", "*.jsx"], {
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter(Boolean)
+  : explicit
+
+const stamped = []
+const already = []
+const skipped = []
+const missing = []
+
+for (const file of targets) {
+  let content
+  try {
+    content = readFileSync(file, "utf8")
+  } catch {
+    continue // file was deleted between staging and run
+  }
+  const c = classify(file, content)
+  if (c.status === "skip") skipped.push(`${file} (${c.reason})`)
+  else if (c.status === "stamped") already.push(file)
+  else if (fix) {
+    writeFileSync(file, applyHeader(content))
+    stamped.push(file)
+  } else missing.push(file)
+}
+
+if (fix) {
+  console.log(
+    `license-header: stamped ${stamped.length}, already ${already.length}, skipped ${skipped.length}`
+  )
+  for (const f of stamped) console.log(`  + ${f}`)
+} else if (missing.length) {
+  console.error(
+    `license-header: ${missing.length} file(s) missing an SPDX header:`
+  )
+  for (const f of missing) console.error(`  - ${f}`)
+  console.error('Run "pnpm run license:fix" to add them.')
+  process.exit(1)
+} else {
+  console.log(
+    `license-header: OK — ${already.length} stamped, ${skipped.length} skipped`
+  )
+}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import ky, { type Options } from "ky"
 
 export const baseUrl = import.meta.env.VITE_API_URL || "/api"

--- a/src/api/handlers.ts
+++ b/src/api/handlers.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { http, HttpResponse, type HttpHandler } from "msw"
 
 /**

--- a/src/api/orval-client.ts
+++ b/src/api/orval-client.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { api } from "./api"
 
 /**

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { Link } from "@tanstack/react-router"
 import type { ErrorComponentProps } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"

--- a/src/components/not-found.tsx
+++ b/src/components/not-found.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { Link } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext, useContext, useEffect, useState } from "react"
 
 type Theme = "dark" | "light" | "system"

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { Moon, Monitor, Sun } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/components/theme-provider"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/src/lib/analytics.tsx
+++ b/src/lib/analytics.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext, useContext, useMemo } from "react"
 import { logger } from "@/lib/logger"
 

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 const STATUS_MESSAGES: Record<number, string> = {
   400: "Invalid request. Please check your input.",
   401: "Your session has expired. Please sign in again.",

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { useQueryClient } from "@tanstack/react-query"
 import {
   createContext,

--- a/src/lib/feature-flags.tsx
+++ b/src/lib/feature-flags.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createContext, useContext, useMemo } from "react"
 import { api } from "@/api/api"

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 type LogLevel = "debug" | "info" | "warn" | "error"
 
 const LEVEL_ORDER: Record<LogLevel, number> = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   MutationCache,
   QueryClient,

--- a/src/pages/home/home-page.test.tsx
+++ b/src/pages/home/home-page.test.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { renderWithFileRoutes } from "@/test/renderers"
 import { screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { Button } from "@/components/ui/button"
 
 export function HomePage() {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { lazy, Suspense, useEffect } from "react"
 import { QueryClient } from "@tanstack/react-query"
 import {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { createFileRoute } from "@tanstack/react-router"
 import { HomePage } from "@/pages/home/home-page"
 

--- a/src/test/renderers.tsx
+++ b/src/test/renderers.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { ThemeProvider } from "@/components/theme-provider"
 import { AnalyticsProvider } from "@/lib/analytics"
 import { AuthProvider } from "@/lib/auth"

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { handlers } from "@/api/handlers"
 import "@testing-library/jest-dom/vitest"
 import { cleanup } from "@testing-library/react"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import path from "path"
 import tailwindcss from "@tailwindcss/vite"
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config"
 import react from "@vitejs/plugin-react"
 import path from "path"


### PR DESCRIPTION
## What

- Add SPDX license headers (`Apache-2.0`, AG Technology Group LLC) to every tracked TypeScript/JS source file (30 files).
- Add an attribution-only `NOTICE` at the repo root.

## Enforcement (CI-only)

- `scripts/license-header.mjs` — dependency-free Node check/stamp tool.
  - The CI `lint-and-test` job runs `pnpm run license:check`.
  - Run `pnpm run license:fix` to stamp new files locally.
- Deliberately **not** wired into husky/lint-staged. This is a template repo: a local hook would be inherited by every clone and have to be ripped out. The check only verifies that an `SPDX-License-Identifier` line exists, so a downstream fork with its own copyright still passes.

## Skipped

`src/routeTree.gen.ts` and `src/api/generated/` (generated), plus non-source files.

## Verification

`prettier --check`, `eslint` (0 errors), `tsc --noEmit`, and `vitest` (2) all passing; build succeeds; the check is idempotent (30 stamped / 1 skipped).
